### PR TITLE
add anomaly detection model baseline

### DIFF
--- a/src/models/anomaly/__init__.py
+++ b/src/models/anomaly/__init__.py
@@ -1,0 +1,4 @@
+from .model import AnomalyDetector
+from .trainer import train
+
+__all__ = ["AnomalyDetector", "train"]

--- a/src/models/anomaly/model.py
+++ b/src/models/anomaly/model.py
@@ -6,11 +6,10 @@ from sklearn.preprocessing import StandardScaler
 
 from .preprocessor import apply_scaler, extract_features, fit_scaler
 
-
 SEVERITY_THRESHOLDS = {
-    "high":   -0.15,
+    "high": -0.15,
     "medium": -0.05,
-    "low":     0.0,
+    "low": 0.0,
 }
 
 
@@ -25,7 +24,12 @@ def _score_to_severity(score: float) -> str:
 
 
 class AnomalyDetector:
-    def __init__(self, contamination: float = 0.05, n_estimators: int = 100, random_state: int = 42):
+    def __init__(
+        self,
+        contamination: float = 0.05,
+        n_estimators: int = 100,
+        random_state: int = 42,
+    ):
         self.contamination = contamination
         self.n_estimators = n_estimators
         self.random_state = random_state
@@ -51,12 +55,14 @@ class AnomalyDetector:
         scores = self._model.decision_function(X_scaled)
         results = []
         for reading, score in zip(readings, scores):
-            results.append({
-                "node_id": reading.get("node_id"),
-                "timestamp": reading.get("timestamp"),
-                "anomaly_score": round(float(score), 6),
-                "severity": _score_to_severity(float(score)),
-            })
+            results.append(
+                {
+                    "node_id": reading.get("node_id"),
+                    "timestamp": reading.get("timestamp"),
+                    "anomaly_score": round(float(score), 6),
+                    "severity": _score_to_severity(float(score)),
+                }
+            )
         return results
 
     def save(self, path: str | Path) -> None:

--- a/src/models/anomaly/model.py
+++ b/src/models/anomaly/model.py
@@ -1,0 +1,84 @@
+import pickle
+from pathlib import Path
+
+from sklearn.ensemble import IsolationForest
+from sklearn.preprocessing import StandardScaler
+
+from .preprocessor import apply_scaler, extract_features, fit_scaler
+
+
+SEVERITY_THRESHOLDS = {
+    "high":   -0.15,
+    "medium": -0.05,
+    "low":     0.0,
+}
+
+
+def _score_to_severity(score: float) -> str:
+    if score <= SEVERITY_THRESHOLDS["high"]:
+        return "high"
+    if score <= SEVERITY_THRESHOLDS["medium"]:
+        return "medium"
+    if score <= SEVERITY_THRESHOLDS["low"]:
+        return "low"
+    return "normal"
+
+
+class AnomalyDetector:
+    def __init__(self, contamination: float = 0.05, n_estimators: int = 100, random_state: int = 42):
+        self.contamination = contamination
+        self.n_estimators = n_estimators
+        self.random_state = random_state
+        self._model: IsolationForest | None = None
+        self._scaler: StandardScaler | None = None
+
+    def fit(self, readings: list[dict]) -> "AnomalyDetector":
+        X = extract_features(readings)
+        X_scaled, self._scaler = fit_scaler(X)
+        self._model = IsolationForest(
+            contamination=self.contamination,
+            n_estimators=self.n_estimators,
+            random_state=self.random_state,
+        )
+        self._model.fit(X_scaled)
+        return self
+
+    def predict(self, readings: list[dict]) -> list[dict]:
+        if self._model is None or self._scaler is None:
+            raise RuntimeError("Model is not fitted. Call fit() first.")
+        X = extract_features(readings)
+        X_scaled = apply_scaler(X, self._scaler)
+        scores = self._model.decision_function(X_scaled)
+        results = []
+        for reading, score in zip(readings, scores):
+            results.append({
+                "node_id": reading.get("node_id"),
+                "timestamp": reading.get("timestamp"),
+                "anomaly_score": round(float(score), 6),
+                "severity": _score_to_severity(float(score)),
+            })
+        return results
+
+    def save(self, path: str | Path) -> None:
+        path = Path(path)
+        path.mkdir(parents=True, exist_ok=True)
+        with open(path / "detector.pkl", "wb") as f:
+            pickle.dump({"model": self._model, "scaler": self._scaler}, f)
+
+    @classmethod
+    def load(cls, path: str | Path) -> "AnomalyDetector":
+        path = Path(path)
+        with open(path / "detector.pkl", "rb") as f:
+            state = pickle.load(f)
+        detector = cls()
+        detector._model = state["model"]
+        detector._scaler = state["scaler"]
+        return detector
+
+    @property
+    def params(self) -> dict:
+        return {
+            "contamination": self.contamination,
+            "n_estimators": self.n_estimators,
+            "random_state": self.random_state,
+        }

--- a/src/models/anomaly/preprocessor.py
+++ b/src/models/anomaly/preprocessor.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import StandardScaler
+
+
+FEATURE_COLUMNS = ["voltage", "current", "power", "energy_wh", "power_factor", "apparent_power"]
+
+
+def extract_features(readings: list[dict]) -> pd.DataFrame:
+    df = pd.DataFrame(readings)
+    df["apparent_power"] = df["voltage"] * df["current"]
+    # Avoid division by zero for dead circuits
+    df["power_factor"] = np.where(
+        df["apparent_power"] > 0,
+        df["power"] / df["apparent_power"],
+        0.0,
+    )
+    return df[FEATURE_COLUMNS]
+
+
+def fit_scaler(X: pd.DataFrame) -> tuple[np.ndarray, StandardScaler]:
+    scaler = StandardScaler()
+    X_scaled = scaler.fit_transform(X)
+    return X_scaled, scaler
+
+
+def apply_scaler(X: pd.DataFrame, scaler: StandardScaler) -> np.ndarray:
+    return scaler.transform(X)

--- a/src/models/anomaly/preprocessor.py
+++ b/src/models/anomaly/preprocessor.py
@@ -2,8 +2,14 @@ import numpy as np
 import pandas as pd
 from sklearn.preprocessing import StandardScaler
 
-
-FEATURE_COLUMNS = ["voltage", "current", "power", "energy_wh", "power_factor", "apparent_power"]
+FEATURE_COLUMNS = [
+    "voltage",
+    "current",
+    "power",
+    "energy_wh",
+    "power_factor",
+    "apparent_power",
+]
 
 
 def extract_features(readings: list[dict]) -> pd.DataFrame:

--- a/src/models/anomaly/trainer.py
+++ b/src/models/anomaly/trainer.py
@@ -9,6 +9,7 @@ MLflow UI:
     open http://localhost:5000
 """
 
+import os
 import random
 import time
 from pathlib import Path
@@ -77,7 +78,7 @@ def train(
     n_readings: int = 300,
     output_dir: Path = MODEL_OUTPUT_DIR,
 ) -> AnomalyDetector:
-    mlflow.set_tracking_uri("./mlruns")  # type: ignore[attr-defined]
+    mlflow.set_tracking_uri(os.getenv("MLFLOW_TRACKING_URI", "http://localhost:5000"))  # type: ignore[attr-defined]
     mlflow.set_experiment(EXPERIMENT_NAME)  # type: ignore[attr-defined]
 
     readings = _generate_mock_readings(n=n_readings, anomaly_fraction=contamination)

--- a/src/models/anomaly/trainer.py
+++ b/src/models/anomaly/trainer.py
@@ -1,0 +1,103 @@
+"""
+Train the anomaly detection model against mock energy readings.
+
+Usage:
+    python -m src.models.anomaly.trainer
+
+MLflow UI:
+    mlflow ui --backend-store-uri ./mlruns
+    open http://localhost:5000
+"""
+
+import random
+import time
+from pathlib import Path
+
+import mlflow
+import numpy as np
+
+from .model import AnomalyDetector
+
+
+EXPERIMENT_NAME = "anomaly-detection"
+MODEL_OUTPUT_DIR = Path("models/anomaly")
+
+# Mirrors E1 telemetry schema (issue #6)
+_NODE_TYPES = ["plug", "circuit", "main"]
+_NODE_IDS = [f"{t}-{i:02d}" for t in _NODE_TYPES for i in range(1, 6)]
+
+
+def _generate_mock_readings(n: int = 300, anomaly_fraction: float = 0.05) -> list[dict]:
+    rng = random.Random(42)
+    readings = []
+    base_ts = int(time.time() * 1000) - n * 60_000
+
+    for i in range(n):
+        is_anomaly = rng.random() < anomaly_fraction
+        voltage = rng.uniform(220, 240)
+        if is_anomaly:
+            # Simulate theft (unusually high current) or leakage (low voltage drop)
+            current = rng.uniform(15, 30)
+            power = voltage * current * rng.uniform(0.3, 0.5)
+        else:
+            current = rng.uniform(0.5, 10)
+            power = voltage * current * rng.uniform(0.85, 0.99)
+
+        readings.append({
+            "node_id": rng.choice(_NODE_IDS),
+            "timestamp": base_ts + i * 60_000,
+            "voltage": round(voltage, 2),
+            "current": round(current, 3),
+            "power": round(power, 2),
+            "energy_wh": round(power / 60, 4),
+        })
+
+    return readings
+
+
+def _compute_metrics(predictions: list[dict]) -> dict:
+    scores = [p["anomaly_score"] for p in predictions]
+    severities = [p["severity"] for p in predictions]
+    return {
+        "n_readings": len(predictions),
+        "n_anomalies": sum(1 for s in severities if s != "normal"),
+        "anomaly_rate": round(sum(1 for s in severities if s != "normal") / len(predictions), 4),
+        "mean_score": round(float(np.mean(scores)), 6),
+        "min_score": round(float(np.min(scores)), 6),
+        "max_score": round(float(np.max(scores)), 6),
+    }
+
+
+def train(
+    contamination: float = 0.05,
+    n_estimators: int = 100,
+    n_readings: int = 300,
+    output_dir: Path = MODEL_OUTPUT_DIR,
+) -> AnomalyDetector:
+    mlflow.set_tracking_uri("./mlruns")
+    mlflow.set_experiment(EXPERIMENT_NAME)
+
+    readings = _generate_mock_readings(n=n_readings, anomaly_fraction=contamination)
+
+    with mlflow.start_run():
+        detector = AnomalyDetector(contamination=contamination, n_estimators=n_estimators)
+        detector.fit(readings)
+
+        mlflow.log_params({**detector.params, "n_readings": n_readings})
+
+        predictions = detector.predict(readings)
+        metrics = _compute_metrics(predictions)
+        mlflow.log_metrics(metrics)
+
+        detector.save(output_dir)
+        mlflow.log_artifact(str(output_dir / "detector.pkl"))
+
+        print(f"Training complete. Metrics: {metrics}")
+        print(f"Model saved to: {output_dir}")
+        print("View results: mlflow ui --backend-store-uri ./mlruns")
+
+    return detector
+
+
+if __name__ == "__main__":
+    train()

--- a/src/models/anomaly/trainer.py
+++ b/src/models/anomaly/trainer.py
@@ -13,11 +13,10 @@ import random
 import time
 from pathlib import Path
 
-import mlflow
+import mlflow  # type: ignore[attr-defined]
 import numpy as np
 
 from .model import AnomalyDetector
-
 
 EXPERIMENT_NAME = "anomaly-detection"
 MODEL_OUTPUT_DIR = Path("models/anomaly")
@@ -43,14 +42,16 @@ def _generate_mock_readings(n: int = 300, anomaly_fraction: float = 0.05) -> lis
             current = rng.uniform(0.5, 10)
             power = voltage * current * rng.uniform(0.85, 0.99)
 
-        readings.append({
-            "node_id": rng.choice(_NODE_IDS),
-            "timestamp": base_ts + i * 60_000,
-            "voltage": round(voltage, 2),
-            "current": round(current, 3),
-            "power": round(power, 2),
-            "energy_wh": round(power / 60, 4),
-        })
+        readings.append(
+            {
+                "node_id": rng.choice(_NODE_IDS),
+                "timestamp": base_ts + i * 60_000,
+                "voltage": round(voltage, 2),
+                "current": round(current, 3),
+                "power": round(power, 2),
+                "energy_wh": round(power / 60, 4),
+            }
+        )
 
     return readings
 
@@ -61,7 +62,9 @@ def _compute_metrics(predictions: list[dict]) -> dict:
     return {
         "n_readings": len(predictions),
         "n_anomalies": sum(1 for s in severities if s != "normal"),
-        "anomaly_rate": round(sum(1 for s in severities if s != "normal") / len(predictions), 4),
+        "anomaly_rate": round(
+            sum(1 for s in severities if s != "normal") / len(predictions), 4
+        ),
         "mean_score": round(float(np.mean(scores)), 6),
         "min_score": round(float(np.min(scores)), 6),
         "max_score": round(float(np.max(scores)), 6),
@@ -74,23 +77,25 @@ def train(
     n_readings: int = 300,
     output_dir: Path = MODEL_OUTPUT_DIR,
 ) -> AnomalyDetector:
-    mlflow.set_tracking_uri("./mlruns")
-    mlflow.set_experiment(EXPERIMENT_NAME)
+    mlflow.set_tracking_uri("./mlruns")  # type: ignore[attr-defined]
+    mlflow.set_experiment(EXPERIMENT_NAME)  # type: ignore[attr-defined]
 
     readings = _generate_mock_readings(n=n_readings, anomaly_fraction=contamination)
 
-    with mlflow.start_run():
-        detector = AnomalyDetector(contamination=contamination, n_estimators=n_estimators)
+    with mlflow.start_run():  # type: ignore[attr-defined]
+        detector = AnomalyDetector(
+            contamination=contamination, n_estimators=n_estimators
+        )
         detector.fit(readings)
 
-        mlflow.log_params({**detector.params, "n_readings": n_readings})
+        mlflow.log_params({**detector.params, "n_readings": n_readings})  # type: ignore[attr-defined]
 
         predictions = detector.predict(readings)
         metrics = _compute_metrics(predictions)
-        mlflow.log_metrics(metrics)
+        mlflow.log_metrics(metrics)  # type: ignore[attr-defined]
 
         detector.save(output_dir)
-        mlflow.log_artifact(str(output_dir / "detector.pkl"))
+        mlflow.log_artifact(str(output_dir / "detector.pkl"))  # type: ignore[attr-defined]
 
         print(f"Training complete. Metrics: {metrics}")
         print(f"Model saved to: {output_dir}")


### PR DESCRIPTION
## What does this PR do?
Isolation Forest model for energy theft and leakage detection. Outputs anomaly score and severity per reading, logs to MLflow.

## Related issue
Closes #13

## How to test it
1. Create and activate a virtual environment, install requirements.txt
3. Run: `python -m src.models.anomaly.trainer`                         
4. Start MLflow UI: `mlflow ui --backend-store-uri ./mlruns`     
5. Open `http://localhost:5000` - verify anomaly detection experiment has a run with 6 metrics logged    

## Anything to flag?
- Blocked by #6 and #15 for  Sprint 2 integration.                                                
- Currently uses inline synthetic data and logs to `./mlruns` locally. 
- Swapping in real fixtures and tracking URI will be a one line change each.     
