### PR TITLE
Postgres schema ingestion

### DIFF
--- a/db/postgres/migrations/001_init.sql
+++ b/db/postgres/migrations/001_init.sql
@@ -1,0 +1,60 @@
+CREATE TABLE IF NOT EXISTS telemetry_readings (
+    id SERIAL PRIMARY KEY,
+    node_id TEXT NOT NULL,
+    timestamp BIGINT NOT NULL,
+    voltage DOUBLE PRECISION NOT NULL,
+    current DOUBLE PRECISION NOT NULL,
+    power DOUBLE PRECISION NOT NULL,
+    energy_wh DOUBLE PRECISION NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW(),
+    UNIQUE (node_id, timestamp)
+);
+
+CREATE TABLE IF NOT EXISTS node_events (
+    id SERIAL PRIMARY KEY,
+    node_id TEXT NOT NULL,
+    node_type TEXT,
+    timestamp BIGINT NOT NULL,
+    event_type TEXT NOT NULL,
+    severity TEXT NOT NULL,
+    message TEXT NOT NULL,
+    buffered BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS node_health (
+    id SERIAL PRIMARY KEY,
+    node_id TEXT NOT NULL,
+    node_type TEXT,
+    timestamp BIGINT NOT NULL,
+    sequence_no INTEGER,
+    status TEXT,
+    uptime_sec INTEGER,
+    mqtt_connected BOOLEAN,
+    wifi_connected BOOLEAN,
+    sensor_ok BOOLEAN,
+    buffered_count INTEGER,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS node_metadata (
+    node_id TEXT PRIMARY KEY,
+    node_type TEXT NOT NULL,
+    location TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS anomaly_records (
+    id SERIAL PRIMARY KEY,
+    node_id TEXT NOT NULL,
+    timestamp BIGINT NOT NULL,
+    anomaly_type TEXT NOT NULL,
+    score DOUBLE PRECISION NOT NULL,
+    severity TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS forecasts (
+    id SERIAL PRIMARY KEY,
+    node_id TEXT NOT NULL,
+    timestamp BIGINT NOT NULL,
+    predicted_consumption DOUBLE PRECISION NOT NULL
+);

--- a/db/postgres/schema.sql
+++ b/db/postgres/schema.sql
@@ -1,0 +1,60 @@
+CREATE TABLE IF NOT EXISTS telemetry_readings (
+    id SERIAL PRIMARY KEY,
+    node_id TEXT NOT NULL,
+    timestamp BIGINT NOT NULL,
+    voltage DOUBLE PRECISION NOT NULL,
+    current DOUBLE PRECISION NOT NULL,
+    power DOUBLE PRECISION NOT NULL,
+    energy_wh DOUBLE PRECISION NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW(),
+    UNIQUE (node_id, timestamp)
+);
+
+CREATE TABLE IF NOT EXISTS node_events (
+    id SERIAL PRIMARY KEY,
+    node_id TEXT NOT NULL,
+    node_type TEXT,
+    timestamp BIGINT NOT NULL,
+    event_type TEXT NOT NULL,
+    severity TEXT NOT NULL,
+    message TEXT NOT NULL,
+    buffered BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS node_health (
+    id SERIAL PRIMARY KEY,
+    node_id TEXT NOT NULL,
+    node_type TEXT,
+    timestamp BIGINT NOT NULL,
+    sequence_no INTEGER,
+    status TEXT,
+    uptime_sec INTEGER,
+    mqtt_connected BOOLEAN,
+    wifi_connected BOOLEAN,
+    sensor_ok BOOLEAN,
+    buffered_count INTEGER,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS node_metadata (
+    node_id TEXT PRIMARY KEY,
+    node_type TEXT NOT NULL,
+    location TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS anomaly_records (
+    id SERIAL PRIMARY KEY,
+    node_id TEXT NOT NULL,
+    timestamp BIGINT NOT NULL,
+    anomaly_type TEXT NOT NULL,
+    score DOUBLE PRECISION NOT NULL,
+    severity TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS forecasts (
+    id SERIAL PRIMARY KEY,
+    node_id TEXT NOT NULL,
+    timestamp BIGINT NOT NULL,
+    predicted_consumption DOUBLE PRECISION NOT NULL
+);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,55 @@
+services:
+  mosquitto:
+    image: eclipse-mosquitto:2
+    container_name: energy-mosquitto
+    ports:
+      - "1883:1883"
+    restart: unless-stopped
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    container_name: energy-zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+    restart: unless-stopped
+
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    container_name: energy-kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:16
+    container_name: energy-postgres
+    environment:
+      POSTGRES_USER: energy_user
+      POSTGRES_PASSWORD: energy_pass
+      POSTGRES_DB: energy_db
+    ports:
+      - "5432:5432"
+    restart: unless-stopped
+
+  influxdb:
+    image: influxdb:2.7
+    container_name: energy-influxdb
+    ports:
+      - "8086:8086"
+    environment:
+      DOCKER_INFLUXDB_INIT_MODE: setup
+      DOCKER_INFLUXDB_INIT_USERNAME: admin
+      DOCKER_INFLUXDB_INIT_PASSWORD: admin12345
+      DOCKER_INFLUXDB_INIT_ORG: energy-org
+      DOCKER_INFLUXDB_INIT_BUCKET: energy_data
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: energy-token-123
+    restart: unless-stopped


### PR DESCRIPTION
## What does this PR do?

Defines the PostgreSQL schema for the E2 data layer.

* Creates tables for telemetry, metadata, anomaly detection, and forecasting
* Uses appropriate data types (e.g., BIGINT for timestamps, DOUBLE PRECISION for numeric fields)
* Adds constraints such as primary keys and uniqueness for telemetry records

---

## Related issue

Closes #7

---

## How to test it

1. Start PostgreSQL container:

   ```bash
   docker compose up -d
   ```

2. Apply schema:

   ```bash
   docker exec -i energy-postgres psql -U energy_user -d energy_db < db/postgres/schema.sql
   ```

3. Verify tables:

   ```bash
   docker exec -it energy-postgres psql -U energy_user -d energy_db -c "\dt"
   ```

4. Expected tables include:

   * telemetry_readings
   * node_metadata
   * anomaly_records
   * forecasts

---

## Anything to flag?

* Includes additional tables for node events and health tracking
* Schema is designed for extensibility for future analytics and processing layers
