### PR TITLE
Stream validation foundation

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Core package for data intelligence modules."""

--- a/src/streaming/README.md
+++ b/src/streaming/README.md
@@ -1,0 +1,23 @@
+# Stream Processing
+
+This module contains the Sprint 1 baseline stream processor for telemetry data.
+
+Current behavior:
+- reads mock telemetry records from `tests/fixtures/energy-readings.json`
+- parses each message from JSON
+- validates each message using `src.validation.telemetry_expectations`
+- groups valid records into 2-second tumbling windows
+- prints one summary per window with the valid record count
+
+Windowing:
+- window size is `2000` milliseconds
+
+## Run Locally
+
+From the `data-intelligence` folder:
+
+```bash
+python3 -m src.streaming.stream_processor
+```
+
+This is a mock-data version for Sprint 1. Kafka input and output can be added in Sprint 2.

--- a/src/streaming/__init__.py
+++ b/src/streaming/__init__.py
@@ -1,0 +1,1 @@
+"""Streaming package."""

--- a/src/streaming/stream_processor.py
+++ b/src/streaming/stream_processor.py
@@ -48,6 +48,31 @@ def process_stream(messages):
 
     return results
 
+def summarize_windows(results, window_size_ms=2000):
+    """Summarize results into time windows."""
+    window_summaries = {}
+
+    for result in results:
+        data = result["data"]
+
+        if result["status"] == "invalid":
+            continue
+
+        timestamp = data["timestamp"]
+        window_start = (timestamp // window_size_ms) * window_size_ms
+        window_end = window_start + window_size_ms -1
+
+        if window_start not in window_summaries:
+            window_summaries[window_start] = {
+                "window_start": window_start,
+                "window_end": window_end,
+                "valid_record_count": 0,
+            }
+        
+        window_summaries[window_start]["valid_record_count"] += 1
+
+    return list(window_summaries.values())
+
 
 if __name__ == "__main__":
 
@@ -60,10 +85,8 @@ if __name__ == "__main__":
             message = json.dumps(record)
             energy_readings.append(message)
 
-
-
-
     results = process_stream(energy_readings)
+    window_summaries = summarize_windows(results)
 
-    for result in results:
-        print(result)
+    for summary in window_summaries:
+        print(summary)

--- a/src/streaming/stream_processor.py
+++ b/src/streaming/stream_processor.py
@@ -48,6 +48,7 @@ def process_stream(messages):
 
     return results
 
+
 def summarize_windows(results, window_size_ms=2000):
     """Summarize results into time windows."""
     window_summaries = {}
@@ -60,7 +61,7 @@ def summarize_windows(results, window_size_ms=2000):
 
         timestamp = data["timestamp"]
         window_start = (timestamp // window_size_ms) * window_size_ms
-        window_end = window_start + window_size_ms -1
+        window_end = window_start + window_size_ms - 1
 
         if window_start not in window_summaries:
             window_summaries[window_start] = {
@@ -68,7 +69,7 @@ def summarize_windows(results, window_size_ms=2000):
                 "window_end": window_end,
                 "valid_record_count": 0,
             }
-        
+
         window_summaries[window_start]["valid_record_count"] += 1
 
     return list(window_summaries.values())
@@ -77,7 +78,7 @@ def summarize_windows(results, window_size_ms=2000):
 if __name__ == "__main__":
 
     # open the sample data file and load the energy readings
-    with open ("tests/fixtures/energy-readings.json", "r") as f:
+    with open("tests/fixtures/energy-readings.json", "r") as f:
         records = json.load(f)
         energy_readings = []
 

--- a/src/streaming/stream_processor.py
+++ b/src/streaming/stream_processor.py
@@ -1,0 +1,62 @@
+import json
+
+from src.validation.telemetry_expectations import validate_telemetry
+
+
+def parse_message(message):
+    """Convert one JSON message string into a Python dictionary."""
+    try:
+        return json.loads(message)
+    except json.JSONDecodeError:
+        return None
+
+
+def process_message(message):
+    """Parse and validate one telemetry message."""
+    data = parse_message(message)
+
+    if data is None:
+        return {
+            "status": "invalid",
+            "reason": "Invalid JSON format",
+            "data": message,
+        }
+
+    is_valid, validation_message = validate_telemetry(data)
+
+    if is_valid:
+        return {
+            "status": "valid",
+            "reason": validation_message,
+            "data": data,
+        }
+
+    return {
+        "status": "invalid",
+        "reason": validation_message,
+        "data": data,
+    }
+
+
+def process_stream(messages):
+    """Process many messages one by one and return all results."""
+    results = []
+
+    for message in messages:
+        result = process_message(message)
+        results.append(result)
+
+    return results
+
+
+if __name__ == "__main__":
+    sample_messages = [
+        '{"node_id":"plug_01","timestamp":1618032900000,"voltage":230.1,"current":1.78,"power":401.6,"energy_wh":1250.4}',
+        '{"node_id":"plug_02","timestamp":"bad_timestamp","voltage":230.0,"current":1.5,"power":345.0,"energy_wh":1200.0}',
+        "invalid json",
+    ]
+
+    results = process_stream(sample_messages)
+
+    for result in results:
+        print(result)

--- a/src/streaming/stream_processor.py
+++ b/src/streaming/stream_processor.py
@@ -50,13 +50,20 @@ def process_stream(messages):
 
 
 if __name__ == "__main__":
-    sample_messages = [
-        '{"node_id":"plug_01","timestamp":1618032900000,"voltage":230.1,"current":1.78,"power":401.6,"energy_wh":1250.4}',
-        '{"node_id":"plug_02","timestamp":"bad_timestamp","voltage":230.0,"current":1.5,"power":345.0,"energy_wh":1200.0}',
-        "invalid json",
-    ]
 
-    results = process_stream(sample_messages)
+    # open the sample data file and load the energy readings
+    with open ("tests/fixtures/energy-readings.json", "r") as f:
+        records = json.load(f)
+        energy_readings = []
+
+        for record in records:
+            message = json.dumps(record)
+            energy_readings.append(message)
+
+
+
+
+    results = process_stream(energy_readings)
 
     for result in results:
         print(result)

--- a/src/validation/__init__.py
+++ b/src/validation/__init__.py
@@ -1,0 +1,1 @@
+"""Validation package."""

--- a/src/validation/telemetry_expectations.py
+++ b/src/validation/telemetry_expectations.py
@@ -22,15 +22,26 @@ def validate_telemetry(data):
     if not isinstance(data["timestamp"], int):
         return False, "Field 'timestamp' must be an integer"
 
+    if data["timestamp"] <= 0:
+        return False, "Field 'timestamp' must be positive"
+
+    if len(str(data["timestamp"])) != 13:
+        return False, "Field 'timestamp' must be a valid epoch ms value"
+
     for field in ["voltage", "current", "power", "energy_wh"]:
         if not isinstance(data[field], (int, float)):
             return False, f"Field '{field}' must be a number"
 
-    if data["voltage"] <= 0:
-        return False, "Field 'voltage' must be greater than 0"
+    if not 200 <= data["voltage"] <= 250:
+        return False, "Field 'voltage' must be between 200 and 250"
 
-    for field in ["current", "power", "energy_wh"]:
-        if data[field] < 0:
-            return False, f"Field '{field}' must be a non-negative number"
+    if data["current"] <= 0:
+        return False, "Field 'current' must be greater than 0"
+
+    if data["power"] <= 0:
+        return False, "Field 'power' must be greater than 0"
+
+    if data["energy_wh"] < 0:
+        return False, "Field 'energy_wh' must be a non-negative number"
 
     return True, "Telemetry data is valid"

--- a/src/validation/telemetry_expectations.py
+++ b/src/validation/telemetry_expectations.py
@@ -1,0 +1,36 @@
+
+REQUIRED_FIELDS = [
+    "node_id",
+    "timestamp",
+    "voltage",
+    "current",
+    "power",
+    "energy_wh",
+]
+
+
+def validate_telemetry(data):
+    """Check whether one telemetry message has the required fields and values."""
+
+    for field in REQUIRED_FIELDS:
+        if field not in data:
+            return False, f"Missing required field: {field}"
+
+    if not isinstance(data["node_id"], str):
+        return False, "Field 'node_id' must be a string"
+
+    if not isinstance(data["timestamp"], int):
+        return False, "Field 'timestamp' must be an integer"
+
+    for field in ["voltage", "current", "power", "energy_wh"]:
+        if not isinstance(data[field], (int, float)):
+            return False, f"Field '{field}' must be a number"
+
+    if data["voltage"] <= 0:
+        return False, "Field 'voltage' must be greater than 0"
+
+    for field in ["current", "power", "energy_wh"]:
+        if data[field] < 0:
+            return False, f"Field '{field}' must be a non-negative number"
+
+    return True, "Telemetry data is valid"

--- a/src/validation/telemetry_expectations.py
+++ b/src/validation/telemetry_expectations.py
@@ -1,4 +1,3 @@
-
 REQUIRED_FIELDS = [
     "node_id",
     "timestamp",

--- a/tests/fixtures/energy-readings.json
+++ b/tests/fixtures/energy-readings.json
@@ -45,5 +45,53 @@
         "voltage": 230.9,
         "current": 3.6,
         "energy_wh": 3650.4
+    },
+    {
+        "node_id": "edge_window_end",
+        "timestamp": 1618033201999,
+        "voltage": 200.0,
+        "current": 0.5,
+        "power": 100.0,
+        "energy_wh": 3651.0
+    },
+    {
+        "node_id": "edge_window_start",
+        "timestamp": 1618033202000,
+        "voltage": 250.0,
+        "current": 0.5,
+        "power": 100.0,
+        "energy_wh": 3652.0
+    },
+    {
+        "node_id": "edge_low_voltage",
+        "timestamp": 1618033204000,
+        "voltage": 199.9,
+        "current": 1.0,
+        "power": 210.0,
+        "energy_wh": 3653.0
+    },
+    {
+        "node_id": "edge_zero_current",
+        "timestamp": 1618033206000,
+        "voltage": 220.0,
+        "current": 0,
+        "power": 150.0,
+        "energy_wh": 3654.0
+    },
+    {
+        "node_id": "edge_zero_power",
+        "timestamp": 1618033208000,
+        "voltage": 221.0,
+        "current": 0.8,
+        "power": 0,
+        "energy_wh": 3655.0
+    },
+    {
+        "node_id": "edge_short_timestamp",
+        "timestamp": 1618033208,
+        "voltage": 223.0,
+        "current": 0.9,
+        "power": 200.0,
+        "energy_wh": 3656.0
     }
 ]

--- a/tests/fixtures/energy-readings.json
+++ b/tests/fixtures/energy-readings.json
@@ -1,0 +1,49 @@
+[
+    {
+        "node_id": "plug_01",
+        "timestamp": 1618032900000,
+        "voltage": 230.1,
+        "current": 1.78,
+        "power": 401.6,
+        "energy_wh": 1250.4
+    },
+    {
+        "node_id": "circuit_01",
+        "timestamp": 1618032960000,
+        "voltage": 231.5,
+        "current": 4.2,
+        "power": 972.3,
+        "energy_wh": 4201.8
+    },
+    {
+        "node_id": "plug_02",
+        "timestamp": "1618033020000",
+        "voltage": 229.7,
+        "current": 1.11,
+        "power": 255.0,
+        "energy_wh": 1260.2
+    },
+    {
+        "node_id": "main_01",
+        "timestamp": 1618033080000,
+        "voltage": 232.8,
+        "current": -0.4,
+        "power": 110.5,
+        "energy_wh": 9800.0
+    },
+    {
+        "node_id": "plug_03",
+        "timestamp": 1618033140000,
+        "voltage": 0,
+        "current": 0.95,
+        "power": 218.5,
+        "energy_wh": 890.0
+    },
+    {
+        "node_id": "circuit_02",
+        "timestamp": 1618033200000,
+        "voltage": 230.9,
+        "current": 3.6,
+        "energy_wh": 3650.4
+    }
+]


### PR DESCRIPTION
## What does this PR do?
Adds the Sprint 1 baseline for telemetry validation and stream processing.
Implemented:

- telemetry validation rules for required fields, types, and value ranges
- mock telemetry fixture data with valid, invalid, and edge cases
- baseline stream processor that parses JSON and validates each message
- 2-second tumbling window summaries for valid records using mock data


## Related issue
Closes #10 
Closes #11

## How to test it
from project folder run
`python3 -m src.streaming.stream_processor
`


## Anything to flag?
It does not yet consume from Kafka or publish results to Kafka topics.
Live Kafka integration and full Flink runtime wiring can be added in Sprint 2.


