### PR TITLE
Dockerfile - anomaly detection service

### DIFF
--- a/docker/Dockerfile.anomaly
+++ b/docker/Dockerfile.anomaly
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.anomaly.txt .
+
+RUN pip install --no-cache-dir -r requirements.anomaly.txt
+
+COPY src/ ./src/
+COPY models/ ./models/
+
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONPATH=/app
+
+EXPOSE 8000
+
+CMD ["uvicorn", "src.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/requirements.anomaly.txt
+++ b/requirements.anomaly.txt
@@ -1,0 +1,8 @@
+numpy==1.24.3
+pandas==2.0.3
+scikit-learn==1.3.0
+mlflow==2.7.0
+fastapi==0.103.0
+uvicorn==0.23.2
+pydantic==2.3.0
+python-dotenv==1.0.0


### PR DESCRIPTION
## What does this PR do?

Adds `docker/Dockerfile.anomaly` and a trimmed `requirements.anomaly.txt` with only what the anomaly service needs — scikit-learn, MLflow, FastAPI/uvicorn. No torch, Kafka, Spark, Airflow, etc.

## Related issue
Closes #44

## How to test it

```bash
docker build -f docker/Dockerfile.anomaly -t anomaly-service .
docker run -p 8000:8000 anomaly-service
curl http://localhost:8000/anomalies
```

## Anything to flag?

The trained model (`models/anomaly/detector.pkl`) needs to exist before the container starts — it's copied in at build time, so run training locally first if it's missing.