### PR TITLE
modified  Dockerfile for API

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -2,11 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+COPY requirements-api.txt .
 
-COPY requirements.txt .
-
-RUN pip install --no-cache-dir -r requirements.txt
-
+RUN pip install --no-cache-dir -r requirements-api.txt
 
 COPY . .
 

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -2,9 +2,13 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY . .
+
+COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
+
+
+COPY . .
 
 EXPOSE 8000
 

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -1,0 +1,3 @@
+fastapi==0.103.0
+uvicorn==0.23.2
+pydantic==2.3.0


### PR DESCRIPTION
## What does this PR do?
- Adds a Dockerfile for the FastAPI API service (`docker/Dockerfile.api`)
- Sets up Uvicorn as the application server
- Exposes port 8000 for external access
- Enables containerized deployment of the API

## Related issue
Closes #46

## How to test it
1. Build the Docker image:
   docker build -f docker/Dockerfile.api -t api-service .

2. Run the container:
   docker run -p 8000:8000 api-service

3. Verify the API:
   - http://localhost:8000
   - http://localhost:8000/docs

## Anything to flag?
-Uses a dedicated requirements-api.txt file to install only API-specific dependencies
Build is lighter and avoids unnecessary ML-related packages
-Initial work started earlier, finalized and aligned with requirements in Sprint 2