### PR TITLE
Anomaly detection pipeline integration

### DIFF
--- a/requirements.anomaly.txt
+++ b/requirements.anomaly.txt
@@ -2,7 +2,5 @@ numpy==1.24.3
 pandas==2.0.3
 scikit-learn==1.3.0
 mlflow==2.7.0
-fastapi==0.103.0
-uvicorn==0.23.2
-pydantic==2.3.0
-python-dotenv==1.0.0
+kafka-python==2.0.2
+psycopg2-binary==2.9.7

--- a/src/models/anomaly/__init__.py
+++ b/src/models/anomaly/__init__.py
@@ -1,4 +1,5 @@
 from .model import AnomalyDetector
+from .pipeline import run
 from .trainer import train
 
-__all__ = ["AnomalyDetector", "train"]
+__all__ = ["AnomalyDetector", "run", "train"]

--- a/src/models/anomaly/pipeline.py
+++ b/src/models/anomaly/pipeline.py
@@ -1,0 +1,121 @@
+import json
+import logging
+import os
+import signal
+import sys
+from pathlib import Path
+
+import psycopg2
+from kafka import KafkaConsumer, KafkaProducer
+
+from .model import AnomalyDetector
+
+logger = logging.getLogger(__name__)
+
+KAFKA_BOOTSTRAP_SERVERS = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+INPUT_TOPIC = "energy.telemetry"
+OUTPUT_TOPIC = "energy.anomalies"
+GROUP_ID = "anomaly-detection-group"
+MODEL_PATH = Path(os.getenv("ANOMALY_MODEL_PATH", "models/anomaly"))
+ANOMALY_TYPE = "theft_or_leakage"
+
+POSTGRES_DSN = (
+    f"host={os.getenv('POSTGRES_HOST', 'localhost')} "
+    f"port={os.getenv('POSTGRES_PORT', '5432')} "
+    f"dbname={os.getenv('POSTGRES_DB', 'energy_db')} "
+    f"user={os.getenv('POSTGRES_USER', 'energy_user')} "
+    f"password={os.getenv('POSTGRES_PASSWORD', 'energy_pass')}"
+)
+
+
+def _build_consumer() -> KafkaConsumer:
+    return KafkaConsumer(
+        INPUT_TOPIC,
+        bootstrap_servers=KAFKA_BOOTSTRAP_SERVERS,
+        group_id=GROUP_ID,
+        auto_offset_reset="earliest",
+        value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+    )
+
+
+def _build_producer() -> KafkaProducer:
+    return KafkaProducer(
+        bootstrap_servers=KAFKA_BOOTSTRAP_SERVERS,
+        value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+    )
+
+
+def _write_to_postgres(conn, result: dict) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO anomaly_records (node_id, timestamp, anomaly_type, score, severity)
+            VALUES (%s, %s, %s, %s, %s)
+            """,
+            (
+                result["node_id"],
+                result["timestamp"],
+                ANOMALY_TYPE,
+                result["anomaly_score"],
+                result["severity"],
+            ),
+        )
+    conn.commit()
+
+
+def run() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    if not (MODEL_PATH / "detector.pkl").exists():
+        logger.error(
+            "Model not found at %s. Run `python -m src.models.anomaly.trainer` first.",
+            MODEL_PATH,
+        )
+        sys.exit(1)
+
+    detector = AnomalyDetector.load(MODEL_PATH)
+    logger.info("Loaded anomaly detector from %s", MODEL_PATH)
+
+    consumer = _build_consumer()
+    producer = _build_producer()
+    conn = psycopg2.connect(POSTGRES_DSN)
+    logger.info("Pipeline started — consuming from %s", INPUT_TOPIC)
+
+    def _shutdown(sig, frame):
+        logger.info("Shutting down...")
+        consumer.close()
+        producer.close()
+        conn.close()
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+
+    for message in consumer:
+        try:
+            reading = message.value
+            results = detector.predict([reading])
+            result = results[0]
+
+            if result["severity"] != "normal":
+                _write_to_postgres(conn, result)
+
+                event = {
+                    "node_id": result["node_id"],
+                    "timestamp": result["timestamp"],
+                    "anomaly_type": ANOMALY_TYPE,
+                    "anomaly_score": result["anomaly_score"],
+                    "severity": result["severity"],
+                }
+                producer.send(OUTPUT_TOPIC, value=event)
+                logger.info("Anomaly detected: %s", event)
+
+        except Exception as e:
+            logger.error("Error processing message: %s", e)
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## What does this PR do?

Wires the trained anomaly detection model into a live Kafka pipeline. It consumes raw telemetry from `energy.telemetry`, scores each reading with the IsolationForest model, and for anything that's not normal — writes the record to PostgreSQL and publishes an event to `energy.anomalies`.

## Related issue
Closes #21

## How to test it

First train the model if you haven't already:
```bash
python -m src.models.anomaly.trainer
```

Then start the pipeline:
```bash
KAFKA_BOOTSTRAP_SERVERS=localhost:9092 \
POSTGRES_HOST=localhost \
python -m src.models.anomaly.pipeline
```

Produce a test telemetry message with high current to trigger an anomaly:
```bash
docker exec -i energy-kafka kafka-console-producer \
  --bootstrap-server localhost:9092 \
  --topic energy.telemetry
```
```json
{"node_id":"plug_01","timestamp":1712908800000,"voltage":230.0,"current":25.0,"power":2875.0,"energy_wh":47.9}
```

Check the output topic:
```bash
docker exec energy-kafka kafka-console-consumer \
  --bootstrap-server localhost:9092 \
  --topic energy.anomalies \
  --from-beginning \
  --max-messages 1
```

And verify the DB:
```sql
SELECT * FROM anomaly_records ORDER BY id DESC LIMIT 5;
```

## Anything to flag?

- Pipeline reads from `energy.telemetry` directly rather than `energy.telemetry.results` — the Flink results topic only carries `{window_start, window_end, record_count}` which doesn't have enough data to score anomalies
- Model file needs to exist before starting the pipeline (`models/anomaly/detector.pkl`) — it will exit with a clear error if it's missing
- Also updated `requirements.anomaly.txt` — added `kafka-python` and `psycopg2-binary`, removed API deps that had crept in