### PR TITLE
test: add comprehensive unit tests for telemetry processing and valid…

### DIFF
--- a/tests/unit/test-ingestion.py
+++ b/tests/unit/test-ingestion.py
@@ -17,6 +17,7 @@ sys.modules["influx_writer"] = mock_influx_writer
 from kafka_consumer import process_telemetry
 from validator import validate_telemetry
 
+
 def valid_telemetry():
     return {
         "node_id": "plug_01",

--- a/tests/unit/test-ingestion.py
+++ b/tests/unit/test-ingestion.py
@@ -1,24 +1,35 @@
+"""Unit tests for the ingestion and storage layer (issue #29)."""
+
 import sys
 import types
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+# Must come before ingestion imports — kafka_consumer uses bare imports
 INGESTION_PATH = Path(__file__).resolve().parents[2] / "src" / "ingestion"
 sys.path.insert(0, str(INGESTION_PATH))
 
+mock_kafka = types.ModuleType("kafka")
+mock_kafka.KafkaConsumer = Mock()  # type: ignore[attr-defined]
+sys.modules["kafka"] = mock_kafka
+
 mock_db_writer = types.ModuleType("db_writer")
-mock_db_writer.insert_telemetry = Mock()
+mock_db_writer.insert_telemetry = Mock()  # type: ignore[attr-defined]
 sys.modules["db_writer"] = mock_db_writer
 
 mock_influx_writer = types.ModuleType("influx_writer")
-mock_influx_writer.write_telemetry = Mock()
+mock_influx_writer.write_telemetry = Mock()  # type: ignore[attr-defined]
 sys.modules["influx_writer"] = mock_influx_writer
 
-from kafka_consumer import process_telemetry
-from validator import validate_telemetry
+from kafka_consumer import process_telemetry  # noqa: E402
+from validator import validate_telemetry  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
-def valid_telemetry():
+def valid_telemetry() -> dict:
     return {
         "node_id": "plug_01",
         "timestamp": 1777392332445,
@@ -29,9 +40,13 @@ def valid_telemetry():
     }
 
 
+# ---------------------------------------------------------------------------
+# Validator — message parsing
+# ---------------------------------------------------------------------------
+
+
 def test_valid_telemetry_passes_validation():
     is_valid, message = validate_telemetry(valid_telemetry())
-
     assert is_valid is True
     assert message == "Valid telemetry message"
 
@@ -39,9 +54,7 @@ def test_valid_telemetry_passes_validation():
 def test_invalid_timestamp_rejected():
     data = valid_telemetry()
     data["timestamp"] = 123
-
     is_valid, message = validate_telemetry(data)
-
     assert is_valid is False
     assert "timestamp" in message
 
@@ -49,9 +62,7 @@ def test_invalid_timestamp_rejected():
 def test_invalid_voltage_rejected():
     data = valid_telemetry()
     data["voltage"] = 180.0
-
     is_valid, message = validate_telemetry(data)
-
     assert is_valid is False
     assert "voltage" in message
 
@@ -59,9 +70,7 @@ def test_invalid_voltage_rejected():
 def test_current_zero_rejected():
     data = valid_telemetry()
     data["current"] = 0
-
     is_valid, message = validate_telemetry(data)
-
     assert is_valid is False
     assert "current" in message
 
@@ -69,96 +78,113 @@ def test_current_zero_rejected():
 def test_power_zero_rejected():
     data = valid_telemetry()
     data["power"] = 0
-
     is_valid, message = validate_telemetry(data)
-
     assert is_valid is False
     assert "power" in message
 
 
+def test_missing_required_field_rejected():
+    data = valid_telemetry()
+    del data["voltage"]
+    is_valid, message = validate_telemetry(data)
+    assert is_valid is False
+    assert "required" in message.lower() or "field" in message.lower()
+
+
+def test_extra_field_rejected():
+    data = valid_telemetry()
+    data["extra_key"] = "unexpected"
+    is_valid, message = validate_telemetry(data)
+    assert is_valid is False
+
+
+# ---------------------------------------------------------------------------
+# process_telemetry — DB write logic
+# ---------------------------------------------------------------------------
+
+
 @patch("kafka_consumer.write_telemetry")
 @patch("kafka_consumer.insert_telemetry")
-def test_process_telemetry_writes_to_postgres_and_influx(
-    mock_insert_telemetry,
-    mock_write_telemetry,
-):
+def test_invalid_telemetry_skips_db_writes(mock_insert, mock_write):
+    """Invalid messages are dropped (returns True) without touching the DB."""
+    bad_data = valid_telemetry()
+    bad_data["voltage"] = 999.0  # out of range
+
+    result = process_telemetry(bad_data)
+
+    assert result is True
+    mock_insert.assert_not_called()
+    mock_write.assert_not_called()
+
+
+@patch("kafka_consumer.write_telemetry")
+@patch("kafka_consumer.insert_telemetry")
+def test_process_telemetry_writes_to_postgres_and_influx(mock_insert, mock_write):
     data = valid_telemetry()
-    mock_insert_telemetry.return_value = True
+    mock_insert.return_value = True
 
     result = process_telemetry(data)
 
     assert result is True
-    mock_insert_telemetry.assert_called_once_with(data)
-    mock_write_telemetry.assert_called_once_with(data)
+    mock_insert.assert_called_once_with(data)
+    mock_write.assert_called_once_with(data)
 
 
 @patch("kafka_consumer.write_telemetry")
 @patch("kafka_consumer.insert_telemetry")
-def test_duplicate_telemetry_skips_influx_write(
-    mock_insert_telemetry,
-    mock_write_telemetry,
-):
+def test_duplicate_telemetry_skips_influx_write(mock_insert, mock_write):
     data = valid_telemetry()
-    mock_insert_telemetry.return_value = False
+    mock_insert.return_value = False
 
     result = process_telemetry(data)
 
     assert result is True
-    mock_insert_telemetry.assert_called_once_with(data)
-    mock_write_telemetry.assert_not_called()
+    mock_insert.assert_called_once_with(data)
+    mock_write.assert_not_called()
 
 
 @patch("kafka_consumer.write_telemetry")
 @patch("kafka_consumer.insert_telemetry")
-def test_postgres_failure_returns_false_for_retry(
-    mock_insert_telemetry,
-    mock_write_telemetry,
-):
+def test_postgres_failure_returns_false_for_retry(mock_insert, mock_write):
     data = valid_telemetry()
-    mock_insert_telemetry.return_value = None
+    mock_insert.return_value = None
 
     result = process_telemetry(data)
 
     assert result is False
-    mock_insert_telemetry.assert_called_once_with(data)
-    mock_write_telemetry.assert_not_called()
+    mock_insert.assert_called_once_with(data)
+    mock_write.assert_not_called()
 
 
 @patch("kafka_consumer.write_telemetry")
 @patch("kafka_consumer.insert_telemetry")
-def test_influx_failure_logs_warning_but_returns_true(
-    mock_insert_telemetry,
-    mock_write_telemetry,
-    capsys,
-):
+def test_influx_failure_does_not_fail_processing(mock_insert, mock_write):
+    """InfluxDB failure should be swallowed — message is committed, not retried."""
     data = valid_telemetry()
-    mock_insert_telemetry.return_value = True
-    mock_write_telemetry.side_effect = Exception("influx down")
+    mock_insert.return_value = True
+    mock_write.side_effect = Exception("influx down")
 
     result = process_telemetry(data)
 
-    captured = capsys.readouterr()
-
     assert result is True
-    assert "WARNING: InfluxDB write failed" in captured.out
-    mock_insert_telemetry.assert_called_once_with(data)
-    mock_write_telemetry.assert_called_once_with(data)
+    mock_insert.assert_called_once_with(data)
+    mock_write.assert_called_once_with(data)
+
+
+# ---------------------------------------------------------------------------
+# Buffered message handling — embedded timestamp preserved
+# ---------------------------------------------------------------------------
 
 
 @patch("kafka_consumer.write_telemetry")
 @patch("kafka_consumer.insert_telemetry")
-def test_embedded_timestamp_is_preserved(
-    mock_insert_telemetry,
-    mock_write_telemetry,
-):
+def test_embedded_timestamp_is_preserved(mock_insert, mock_write):
+    """Buffered messages carry their original timestamp — it must not be overwritten."""
     data = valid_telemetry()
     data["timestamp"] = 1777000000000
-    mock_insert_telemetry.return_value = True
+    mock_insert.return_value = True
 
     process_telemetry(data)
 
-    written_to_postgres = mock_insert_telemetry.call_args.args[0]
-    written_to_influx = mock_write_telemetry.call_args.args[0]
-
-    assert written_to_postgres["timestamp"] == 1777000000000
-    assert written_to_influx["timestamp"] == 1777000000000
+    assert mock_insert.call_args.args[0]["timestamp"] == 1777000000000
+    assert mock_write.call_args.args[0]["timestamp"] == 1777000000000

--- a/tests/unit/test-ingestion.py
+++ b/tests/unit/test-ingestion.py
@@ -1,1 +1,163 @@
-# Unit tests: Kafka consumer logic and MQTT bridge message parsing
+import sys
+import types
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+INGESTION_PATH = Path(__file__).resolve().parents[2] / "src" / "ingestion"
+sys.path.insert(0, str(INGESTION_PATH))
+
+mock_db_writer = types.ModuleType("db_writer")
+mock_db_writer.insert_telemetry = Mock()
+sys.modules["db_writer"] = mock_db_writer
+
+mock_influx_writer = types.ModuleType("influx_writer")
+mock_influx_writer.write_telemetry = Mock()
+sys.modules["influx_writer"] = mock_influx_writer
+
+from kafka_consumer import process_telemetry
+from validator import validate_telemetry
+
+def valid_telemetry():
+    return {
+        "node_id": "plug_01",
+        "timestamp": 1777392332445,
+        "voltage": 230.0,
+        "current": 1.5,
+        "power": 345.0,
+        "energy_wh": 1200.0,
+    }
+
+
+def test_valid_telemetry_passes_validation():
+    is_valid, message = validate_telemetry(valid_telemetry())
+
+    assert is_valid is True
+    assert message == "Valid telemetry message"
+
+
+def test_invalid_timestamp_rejected():
+    data = valid_telemetry()
+    data["timestamp"] = 123
+
+    is_valid, message = validate_telemetry(data)
+
+    assert is_valid is False
+    assert "timestamp" in message
+
+
+def test_invalid_voltage_rejected():
+    data = valid_telemetry()
+    data["voltage"] = 180.0
+
+    is_valid, message = validate_telemetry(data)
+
+    assert is_valid is False
+    assert "voltage" in message
+
+
+def test_current_zero_rejected():
+    data = valid_telemetry()
+    data["current"] = 0
+
+    is_valid, message = validate_telemetry(data)
+
+    assert is_valid is False
+    assert "current" in message
+
+
+def test_power_zero_rejected():
+    data = valid_telemetry()
+    data["power"] = 0
+
+    is_valid, message = validate_telemetry(data)
+
+    assert is_valid is False
+    assert "power" in message
+
+
+@patch("kafka_consumer.write_telemetry")
+@patch("kafka_consumer.insert_telemetry")
+def test_process_telemetry_writes_to_postgres_and_influx(
+    mock_insert_telemetry,
+    mock_write_telemetry,
+):
+    data = valid_telemetry()
+    mock_insert_telemetry.return_value = True
+
+    result = process_telemetry(data)
+
+    assert result is True
+    mock_insert_telemetry.assert_called_once_with(data)
+    mock_write_telemetry.assert_called_once_with(data)
+
+
+@patch("kafka_consumer.write_telemetry")
+@patch("kafka_consumer.insert_telemetry")
+def test_duplicate_telemetry_skips_influx_write(
+    mock_insert_telemetry,
+    mock_write_telemetry,
+):
+    data = valid_telemetry()
+    mock_insert_telemetry.return_value = False
+
+    result = process_telemetry(data)
+
+    assert result is True
+    mock_insert_telemetry.assert_called_once_with(data)
+    mock_write_telemetry.assert_not_called()
+
+
+@patch("kafka_consumer.write_telemetry")
+@patch("kafka_consumer.insert_telemetry")
+def test_postgres_failure_returns_false_for_retry(
+    mock_insert_telemetry,
+    mock_write_telemetry,
+):
+    data = valid_telemetry()
+    mock_insert_telemetry.return_value = None
+
+    result = process_telemetry(data)
+
+    assert result is False
+    mock_insert_telemetry.assert_called_once_with(data)
+    mock_write_telemetry.assert_not_called()
+
+
+@patch("kafka_consumer.write_telemetry")
+@patch("kafka_consumer.insert_telemetry")
+def test_influx_failure_logs_warning_but_returns_true(
+    mock_insert_telemetry,
+    mock_write_telemetry,
+    capsys,
+):
+    data = valid_telemetry()
+    mock_insert_telemetry.return_value = True
+    mock_write_telemetry.side_effect = Exception("influx down")
+
+    result = process_telemetry(data)
+
+    captured = capsys.readouterr()
+
+    assert result is True
+    assert "WARNING: InfluxDB write failed" in captured.out
+    mock_insert_telemetry.assert_called_once_with(data)
+    mock_write_telemetry.assert_called_once_with(data)
+
+
+@patch("kafka_consumer.write_telemetry")
+@patch("kafka_consumer.insert_telemetry")
+def test_embedded_timestamp_is_preserved(
+    mock_insert_telemetry,
+    mock_write_telemetry,
+):
+    data = valid_telemetry()
+    data["timestamp"] = 1777000000000
+    mock_insert_telemetry.return_value = True
+
+    process_telemetry(data)
+
+    written_to_postgres = mock_insert_telemetry.call_args.args[0]
+    written_to_influx = mock_write_telemetry.call_args.args[0]
+
+    assert written_to_postgres["timestamp"] == 1777000000000
+    assert written_to_influx["timestamp"] == 1777000000000


### PR DESCRIPTION
## What does this PR do?

Adds unit tests for the ingestion and storage layer, including telemetry validation, Kafka consumer processing, duplicate handling, PostgreSQL failure handling, InfluxDB warning behavior, and timestamp preservation. External services are mocked.

---

## Related issue

Closes #29

---

## How to test it

Run:

python3 -m pytest tests/unit/test-ingestion.py

Expected:

10 passed

---

## Anything to flag?

Uses mocks for PostgreSQL and InfluxDB, so no live services are required. This PR only covers unit tests.