### PR TITLE
Streaming validation unit tests

### DIFF
--- a/src/streaming/README.md
+++ b/src/streaming/README.md
@@ -85,6 +85,20 @@ Expected result shape:
 {"window_start":1712908804000,"window_end":1712908806000,"record_count":1}
 ```
 
+## Run Unit Tests
+
+From the `data-intelligence` folder:
+
+```bash
+python -m pytest tests/unit/test-streaming.py -v
+```
+
+To run streaming tests together with the validation tests:
+
+```bash
+python -m pytest tests/unit/test-streaming.py tests/unit/test-validation.py -v
+```
+
 ## Event Time
 
 Telemetry `timestamp` values are epoch milliseconds.

--- a/src/validation/README.md
+++ b/src/validation/README.md
@@ -60,3 +60,17 @@ Expected behavior:
 - logs a validation summary with checked, passed, and failed row counts
 - succeeds when no invalid telemetry rows are found
 - fails the task when invalid telemetry rows are found
+
+## Run Unit Tests
+
+From the `data-intelligence` folder:
+
+```bash
+python -m pytest tests/unit/test-validation.py -v
+```
+
+To run validation tests together with the streaming transformation tests:
+
+```bash
+python -m pytest tests/unit/test-streaming.py tests/unit/test-validation.py -v
+```

--- a/tests/unit/test-streaming.py
+++ b/tests/unit/test-streaming.py
@@ -1,1 +1,123 @@
-# Unit tests: Flink stream processor transformations and windowing logic
+"""Unit tests for Flink stream processor transformations and windowing logic."""
+
+import json
+from unittest.mock import Mock, patch
+
+from src.streaming import telemetry_transforms as transforms
+
+
+def valid_telemetry() -> dict:
+    return {
+        "node_id": "node_001",
+        "timestamp": 1714496400000,
+        "voltage": 230.0,
+        "current": 2.5,
+        "power": 575.0,
+        "energy_wh": 10.5,
+    }
+
+
+def test_validate_message_accepts_valid_telemetry_json():
+    payload = valid_telemetry()
+
+    with patch.object(
+        transforms,
+        "validate_telemetry",
+        return_value=(True, "Telemetry data is valid"),
+    ):
+        result = json.loads(transforms.validate_message(json.dumps(payload)))
+
+    assert result["status"] == "valid"
+    assert result["reason"] == "Telemetry data is valid"
+    assert result["data"] == payload
+
+
+def test_validate_message_rejects_empty_message():
+    result = json.loads(transforms.validate_message(""))
+
+    assert result == {
+        "status": "invalid",
+        "reason": "Empty message",
+        "data": None,
+    }
+
+
+def test_validate_message_rejects_invalid_json():
+    result = json.loads(transforms.validate_message("{bad json"))
+
+    assert result == {
+        "status": "invalid",
+        "reason": "Invalid JSON",
+        "data": None,
+    }
+
+
+def test_validate_message_rejects_invalid_telemetry_values():
+    payload = valid_telemetry()
+    payload["voltage"] = 999.0
+
+    with patch.object(
+        transforms,
+        "validate_telemetry",
+        return_value=(False, "Validation failed for 'voltage'"),
+    ):
+        result = json.loads(transforms.validate_message(json.dumps(payload)))
+
+    assert result["status"] == "invalid"
+    assert result["reason"] == "Validation failed for 'voltage'"
+    assert result["data"] == payload
+
+
+def test_timestamp_assigner_returns_record_timestamp():
+    assigner = transforms.TelemetryTimestampAssigner()
+    payload = valid_telemetry()
+
+    timestamp = assigner.extract_timestamp(payload, record_timestamp=0)
+
+    assert timestamp == payload["timestamp"]
+
+
+def test_summarize_window_returns_window_bounds_and_record_count():
+    window = Mock()
+    window.start = 1000
+    window.end = 3000
+
+    context = Mock()
+    context.window.return_value = window
+
+    records = [valid_telemetry(), valid_telemetry()]
+    result = transforms.SummarizeWindow().process("all", context, records)
+    summary = json.loads(result[0])
+
+    assert summary == {
+        "window_start": 1000,
+        "window_end": 3000,
+        "record_count": 2,
+    }
+
+
+def test_window_records_uses_constant_key_and_two_second_tumbling_window():
+    stream = Mock()
+    keyed_stream = Mock()
+    windowed_stream = Mock()
+    stream.key_by.return_value = keyed_stream
+    keyed_stream.window.return_value = windowed_stream
+
+    with (
+        patch.object(
+            transforms.Time, "milliseconds", return_value="two_seconds"
+        ) as mock_milliseconds,
+        patch.object(
+            transforms.TumblingEventTimeWindows,
+            "of",
+            return_value="window_spec",
+        ) as mock_window_of,
+    ):
+        result = transforms.window_records(stream)
+
+    key_function = stream.key_by.call_args.args[0]
+    assert key_function(valid_telemetry()) == "all"
+    mock_milliseconds.assert_called_once_with(transforms.WINDOW_SIZE_MS)
+    mock_window_of.assert_called_once_with("two_seconds")
+    keyed_stream.window.assert_called_once_with("window_spec")
+    assert result is windowed_stream

--- a/tests/unit/test-streaming.py
+++ b/tests/unit/test-streaming.py
@@ -1,9 +1,33 @@
 """Unit tests for Flink stream processor transformations and windowing logic."""
 
 import json
+import sys
+import types
 from unittest.mock import Mock, patch
 
-from src.streaming import telemetry_transforms as transforms
+# pyflink requires a full Flink/JVM installation not present in the unit test
+# environment — mock it before importing telemetry_transforms, same pattern as
+# test-ingestion.py uses for kafka.
+_pyflink = types.ModuleType("pyflink")
+_pyflink_common = types.ModuleType("pyflink.common")
+_pyflink_common.Duration = Mock()
+_pyflink_common.Time = Mock()
+_pyflink_common.WatermarkStrategy = Mock()
+_pyflink_datastream = types.ModuleType("pyflink.datastream")
+_pyflink_datastream_functions = types.ModuleType("pyflink.datastream.functions")
+_pyflink_datastream_functions.ProcessWindowFunction = object
+_pyflink_datastream_window = types.ModuleType("pyflink.datastream.window")
+_pyflink_datastream_window.TumblingEventTimeWindows = Mock()
+_pyflink_common_watermark = types.ModuleType("pyflink.common.watermark_strategy")
+_pyflink_common_watermark.TimestampAssigner = object
+sys.modules["pyflink"] = _pyflink
+sys.modules["pyflink.common"] = _pyflink_common
+sys.modules["pyflink.datastream"] = _pyflink_datastream
+sys.modules["pyflink.datastream.functions"] = _pyflink_datastream_functions
+sys.modules["pyflink.datastream.window"] = _pyflink_datastream_window
+sys.modules["pyflink.common.watermark_strategy"] = _pyflink_common_watermark
+
+from src.streaming import telemetry_transforms as transforms  # noqa: E402
 
 
 def valid_telemetry() -> dict:

--- a/tests/unit/test-validation.py
+++ b/tests/unit/test-validation.py
@@ -1,1 +1,129 @@
-# Unit tests: Great Expectations data quality checks and validation rules
+"""Unit tests for Great Expectations telemetry validation rules."""
+
+import great_expectations as gx
+
+from src.validation.telemetry_expectations import (
+    build_telemetry_suite,
+    validate_telemetry,
+)
+
+
+def valid_telemetry() -> dict:
+    return {
+        "node_id": "node_001",
+        "timestamp": 1714496400000,
+        "voltage": 230.0,
+        "current": 2.5,
+        "power": 575.0,
+        "energy_wh": 10.5,
+    }
+
+
+def assert_invalid(data: dict, expected_text: str):
+    is_valid, message = validate_telemetry(data)
+
+    assert is_valid is False
+    assert expected_text in message
+
+
+def test_valid_telemetry_passes_great_expectations_validation():
+    is_valid, message = validate_telemetry(valid_telemetry())
+
+    assert is_valid is True
+    assert message == "Telemetry data is valid"
+
+
+def test_missing_required_field_fails_validation():
+    data = valid_telemetry()
+    del data["voltage"]
+
+    assert_invalid(data, "voltage")
+
+
+def test_extra_unexpected_field_fails_validation():
+    data = valid_telemetry()
+    data["unexpected"] = "value"
+
+    assert_invalid(data, "table")
+
+
+def test_wrong_node_id_type_fails_validation():
+    data = valid_telemetry()
+    data["node_id"] = 123
+
+    assert_invalid(data, "node_id")
+
+
+def test_wrong_timestamp_type_fails_validation():
+    data = valid_telemetry()
+    data["timestamp"] = "1714496400000"
+
+    assert_invalid(data, "timestamp")
+
+
+def test_timestamp_outside_epoch_millisecond_range_fails_validation():
+    data = valid_telemetry()
+    data["timestamp"] = 123
+
+    assert_invalid(data, "timestamp")
+
+
+def test_voltage_below_allowed_range_fails_validation():
+    data = valid_telemetry()
+    data["voltage"] = 199.9
+
+    assert_invalid(data, "voltage")
+
+
+def test_voltage_above_allowed_range_fails_validation():
+    data = valid_telemetry()
+    data["voltage"] = 250.1
+
+    assert_invalid(data, "voltage")
+
+
+def test_zero_current_fails_validation():
+    data = valid_telemetry()
+    data["current"] = 0
+
+    assert_invalid(data, "current")
+
+
+def test_zero_power_fails_validation():
+    data = valid_telemetry()
+    data["power"] = 0
+
+    assert_invalid(data, "power")
+
+
+def test_negative_energy_wh_fails_validation():
+    data = valid_telemetry()
+    data["energy_wh"] = -1
+
+    assert_invalid(data, "energy_wh")
+
+
+def test_build_telemetry_suite_contains_required_rules():
+    gx.get_context()
+    suite = build_telemetry_suite()
+    expectations = suite.expectations
+    expectation_types = {expectation.__class__.__name__ for expectation in expectations}
+    expectation_columns = {
+        expectation.column
+        for expectation in expectations
+        if hasattr(expectation, "column")
+    }
+
+    assert len(expectations) == 12
+    assert "ExpectTableColumnsToMatchSet" in expectation_types
+    assert "ExpectColumnValuesToBeOfType" in expectation_types
+    assert "ExpectColumnValuesToBeInTypeList" in expectation_types
+    assert "ExpectColumnValuesToBeBetween" in expectation_types
+    assert {
+        "node_id",
+        "timestamp",
+        "voltage",
+        "current",
+        "power",
+        "energy_wh",
+    } <= expectation_columns


### PR DESCRIPTION
## What does this PR do?

Adds unit tests for the Flink streaming transformation layer and Great Expectations telemetry validation rules.

- Tests valid and invalid streaming message validation
- Tests timestamp assignment and 2-second window setup
- Tests window summary output
- Tests valid telemetry data against Great Expectations rules
- Tests invalid telemetry cases for missing fields, extra fields, wrong types, and invalid ranges

## Related issue

Closes #30 

## How to test it

```bash
python -m pytest tests/unit/test-streaming.py tests/unit/test-validation.py -v
```