### PR TITLE
feat: wire live model outputs into API (issue #28)

### DIFF
--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -1,3 +1,6 @@
 fastapi==0.103.0
 uvicorn==0.23.2
 pydantic==2.3.0
+sqlalchemy==2.0.20
+psycopg2-binary==2.9.7
+pandas==2.0.3

--- a/src/api/dependencies.py
+++ b/src/api/dependencies.py
@@ -1,0 +1,17 @@
+import os
+from functools import lru_cache
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+
+
+@lru_cache(maxsize=1)
+def get_db_engine() -> Engine:
+    url = (
+        f"postgresql://{os.getenv('POSTGRES_USER', 'energy_user')}"
+        f":{os.getenv('POSTGRES_PASSWORD', 'energy_pass')}"
+        f"@{os.getenv('POSTGRES_HOST', 'postgres')}"
+        f":{os.getenv('POSTGRES_PORT', '5432')}"
+        f"/{os.getenv('POSTGRES_DB', 'energy_db')}"
+    )
+    return create_engine(url, pool_pre_ping=True)

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -15,7 +15,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 # Import route modules from other teams
-from src.api.routes import forecasting, health
+from src.api.routes import anomalies, forecasting, health, recommendations
 
 # ============================================
 # Create FastAPI Application
@@ -50,6 +50,8 @@ app.add_middleware(
 # This is where multiple teams combine their work
 app.include_router(health.router)
 app.include_router(forecasting.router)
+app.include_router(anomalies.router)
+app.include_router(recommendations.router)
 
 # When Person 4 creates their API infrastructure routes, they'll add:
 # app.include_router(api_routes.router)
@@ -75,8 +77,11 @@ def root():
         "team": "E2 Data & Intelligence",
         "endpoints": {
             "health": "/health (GET)",
-            "forecast": "/forecast/predict (POST)",
+            "forecasts": "/forecast/forecasts (GET)",
+            "forecast_predict": "/forecast/predict (POST)",
             "forecast_batch": "/forecast/predict-batch (POST)",
+            "anomalies": "/anomalies (GET)",
+            "recommendations": "/recommendations (GET)",
             "documentation": "/docs (GET)",
         },
         "docs_url": "/docs",

--- a/src/api/routes/anomalies.py
+++ b/src/api/routes/anomalies.py
@@ -21,7 +21,9 @@ class AnomalyRecord(BaseModel):
 @router.get("", response_model=List[AnomalyRecord])
 def get_anomalies(
     node_id: Optional[str] = Query(None, description="Filter by node ID"),
-    severity: Optional[str] = Query(None, description="Filter by severity: high, medium, normal"),
+    severity: Optional[str] = Query(
+        None, description="Filter by severity: high, medium, normal"
+    ),
     limit: int = Query(100, ge=1, le=1000, description="Max records to return"),
     engine: Engine = Depends(get_db_engine),
 ):

--- a/src/api/routes/anomalies.py
+++ b/src/api/routes/anomalies.py
@@ -1,0 +1,53 @@
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from src.api.dependencies import get_db_engine
+
+router = APIRouter(prefix="/anomalies", tags=["anomalies"])
+
+
+class AnomalyRecord(BaseModel):
+    node_id: str
+    timestamp: int
+    anomaly_type: str
+    score: float
+    severity: str
+
+
+@router.get("", response_model=List[AnomalyRecord])
+def get_anomalies(
+    node_id: Optional[str] = Query(None, description="Filter by node ID"),
+    severity: Optional[str] = Query(None, description="Filter by severity: high, medium, normal"),
+    limit: int = Query(100, ge=1, le=1000, description="Max records to return"),
+    engine: Engine = Depends(get_db_engine),
+):
+    """Return anomaly records from PostgreSQL, newest first."""
+    filters = []
+    params: dict = {"limit": limit}
+
+    if node_id:
+        filters.append("node_id = :node_id")
+        params["node_id"] = node_id
+    if severity:
+        filters.append("severity = :severity")
+        params["severity"] = severity
+
+    where = f"WHERE {' AND '.join(filters)}" if filters else ""
+    query = text(f"""
+        SELECT node_id, timestamp, anomaly_type, score, severity
+        FROM anomaly_records
+        {where}
+        ORDER BY timestamp DESC
+        LIMIT :limit
+    """)
+
+    try:
+        with engine.connect() as conn:
+            rows = conn.execute(query, params).mappings().all()
+        return [dict(r) for r in rows]
+    except Exception as e:
+        raise HTTPException(status_code=503, detail=f"Database error: {e}")

--- a/src/api/routes/forecasting.py
+++ b/src/api/routes/forecasting.py
@@ -5,17 +5,20 @@ This module provides HTTP endpoints for making 24-hour energy consumption
 forecasts using the trained LSTM neural network model.
 """
 
-from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
-import torch
-import numpy as np
-import os
 from typing import List, Optional
 
+import numpy as np
+import os
+import torch
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from src.api.dependencies import get_db_engine
 from src.models.forecasting.lstm_model import LSTMForecaster
 from sklearn.preprocessing import MinMaxScaler
 
-# Create a router for forecasting endpoints
 router = APIRouter(prefix="/forecast", tags=["forecasting"])
 
 # Global variables to hold the model and scaler (loaded once at startup)
@@ -286,3 +289,40 @@ def predict_batch(request: BatchPredictionRequest):
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Batch prediction error: {str(e)}")
+
+
+class ForecastRecord(BaseModel):
+    node_id: str
+    timestamp: int
+    predicted_consumption: float
+
+
+@router.get("/forecasts", response_model=List[ForecastRecord])
+def get_forecasts(
+    node_id: Optional[str] = Query(None, description="Filter by node ID"),
+    limit: int = Query(100, ge=1, le=1000, description="Max records to return"),
+    engine: Engine = Depends(get_db_engine),
+):
+    """Return stored forecast rows from PostgreSQL, newest first."""
+    filters = []
+    params: dict = {"limit": limit}
+
+    if node_id:
+        filters.append("node_id = :node_id")
+        params["node_id"] = node_id
+
+    where = f"WHERE {' AND '.join(filters)}" if filters else ""
+    query = text(f"""
+        SELECT node_id, timestamp, predicted_consumption
+        FROM forecasts
+        {where}
+        ORDER BY timestamp DESC
+        LIMIT :limit
+    """)
+
+    try:
+        with engine.connect() as conn:
+            rows = conn.execute(query, params).mappings().all()
+        return [dict(r) for r in rows]
+    except Exception as e:
+        raise HTTPException(status_code=503, detail=f"Database error: {e}")

--- a/src/api/routes/recommendations.py
+++ b/src/api/routes/recommendations.py
@@ -1,0 +1,28 @@
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.engine import Engine
+
+from src.api.dependencies import get_db_engine
+from src.optimization.recommendations import run as run_recommendations
+
+router = APIRouter(prefix="/recommendations", tags=["recommendations"])
+
+
+class RecommendationItem(BaseModel):
+    node_id: str
+    type: str
+    severity: str
+    message: str
+    generated_at: str
+    metadata: Dict[str, Any]
+
+
+@router.get("", response_model=List[RecommendationItem])
+def get_recommendations(engine: Engine = Depends(get_db_engine)):
+    """Generate and return energy optimization recommendations."""
+    try:
+        return run_recommendations(engine=engine)
+    except Exception as e:
+        raise HTTPException(status_code=503, detail=f"Failed to generate recommendations: {e}")

--- a/src/api/routes/recommendations.py
+++ b/src/api/routes/recommendations.py
@@ -25,4 +25,6 @@ def get_recommendations(engine: Engine = Depends(get_db_engine)):
     try:
         return run_recommendations(engine=engine)
     except Exception as e:
-        raise HTTPException(status_code=503, detail=f"Failed to generate recommendations: {e}")
+        raise HTTPException(
+            status_code=503, detail=f"Failed to generate recommendations: {e}"
+        )

--- a/src/optimization/recommendations.py
+++ b/src/optimization/recommendations.py
@@ -17,10 +17,10 @@ from sqlalchemy import create_engine, text
 
 logger = logging.getLogger(__name__)
 
-POSTGRES_HOST = os.getenv("POSTGRES_HOST", "localhost")
+POSTGRES_HOST = os.getenv("POSTGRES_HOST", "postgres")
 POSTGRES_PORT = int(os.getenv("POSTGRES_PORT", "5432"))
-POSTGRES_USER = os.getenv("POSTGRES_USER", "postgres")
-POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD", "postgres")
+POSTGRES_USER = os.getenv("POSTGRES_USER", "energy_user")
+POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD", "energy_pass")
 POSTGRES_DB = os.getenv("POSTGRES_DB", "energy_db")
 
 HIGH_CONSUMPTION_WATTS = float(os.getenv("HIGH_CONSUMPTION_THRESHOLD", "800"))
@@ -61,7 +61,7 @@ def fetch_anomalies(engine=None) -> pd.DataFrame:
     if engine is None:
         engine = _get_engine()
     query = text(f"""
-        SELECT node_id, timestamp, anomaly_score, severity
+        SELECT node_id, timestamp, score AS anomaly_score, severity
         FROM anomaly_records
         WHERE timestamp >= EXTRACT(EPOCH FROM NOW() - INTERVAL '{ANOMALY_LOOKBACK_HOURS} hours') * 1000
         ORDER BY timestamp DESC


### PR DESCRIPTION
## What does this PR do?

Replaces mock/missing API responses with live reads from PostgreSQL and the recommendations engine:

- **`GET /forecast/forecasts`** — reads stored 24h predictions from the `forecasts` table (written by the batch pipeline). Supports `node_id` and `limit` query params.
- **`GET /anomalies`** — reads from `anomaly_records` (written by the real-time anomaly pipeline). Supports `node_id`, `severity`, and `limit` filters.
- **`GET /recommendations`** — runs the optimization recommendations engine against live anomaly + forecast data and returns structured results.
- **`src/api/dependencies.py`** — shared SQLAlchemy engine factory injected into routes via FastAPI `Depends`.
- **`requirements-api.txt`** — added `sqlalchemy`, `psycopg2-binary`, `pandas`.

## Related issue
Closes #28

## How to test it

- `GET /forecast/forecasts` returns rows after the batch pipeline has run; `?node_id=node_001` filters correctly
- `GET /anomalies` returns records; `?severity=high` filters to high-severity only; returns `503` with a message if DB is unreachable
- `GET /recommendations` returns a recommendation list; returns `[]` when no anomalies or forecasts exist in the DB
- `/docs` shows all three new endpoints with correct schemas

## Anything to flag?

`recommendations.py` had a silent bug — it queried column `anomaly_score` but the DB column is `score`. This would have returned empty results or errored at runtime. Fixed here with `score AS anomaly_score` alias. Also fixed wrong default DB credentials (`postgres`/`postgres` → `energy_user`/`energy_pass`).